### PR TITLE
Add space before asterisk in grub config updater hook's messages

### DIFF
--- a/hooks/91-grub-mkconfig.install
+++ b/hooks/91-grub-mkconfig.install
@@ -6,12 +6,12 @@
 
 # familliar helpers, we intentionally don't use gentoo functions.sh
 die() {
-	echo -e "${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
+	echo -e " ${NOCOLOR-\e[1;31m*\e[0m }${*}" >&2
 	exit 1
 }
 
 einfo() {
-        echo -e "${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
+        echo -e " ${NOCOLOR-\e[1;32m*\e[0m }${*}" >&2
 }
 
 main() {


### PR DESCRIPTION
Small, trivial cosmetic change to make the style of `einfo` and `die` messages consistent with other Gentoo programs.

Before:
```
 * Installing the kernel via installkernel ...
run-parts: executing /etc/kernel/postinst.d/91-grub-mkconfig.install 5.16.8 /boot/vmlinuz-5.16.8
* Backing up existing grub config as /boot/grub/grub.cfg~
'/boot/grub/grub.cfg' -> '/boot/grub/grub.cfg~'
* Generating new grub config as /boot/grub/grub.cfg
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.16.8
Found initrd image: /boot/initramfs-5.16.8.img
Found linux image: /boot/vmlinuz-5.16.6
Found initrd image: /boot/initramfs-5.16.6.img
```

After:
```
 * Installing the kernel via installkernel ...
run-parts: executing /etc/kernel/postinst.d/91-grub-mkconfig.install 5.16.8 /boot/vmlinuz-5.16.8
 * Backing up existing grub config as /boot/grub/grub.cfg~
'/boot/grub/grub.cfg' -> '/boot/grub/grub.cfg~'
 * Generating new grub config as /boot/grub/grub.cfg
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.16.8
Found initrd image: /boot/initramfs-5.16.8.img
Found linux image: /boot/vmlinuz-5.16.6
Found initrd image: /boot/initramfs-5.16.6.img
```