### PR TITLE
installkernel: Fixed ShellCheck warnings about globbing and word splitting

### DIFF
--- a/installkernel
+++ b/installkernel
@@ -49,7 +49,7 @@ updatever () {
     if test -L "$dir/$1$3" ; then
         # If we were using links, continue to use links, updating if
         # we need to.
-        if [ "$(readlink -f ${dir}/${1}$3)" = "${dir}/${1}-${ver}$3" ]; then
+        if [ "$(readlink -f "${dir}/${1}$3")" = "${dir}/${1}-${ver}$3" ]; then
             # Yup, we need to change
             ln -sf "$1-$ver$3.old" "$dir/$1$3.old"
         else
@@ -63,7 +63,7 @@ updatever () {
   fi
 }
 
-if [ "$(basename $img)" = "vmlinux" ] ; then
+if [ "$(basename "$img")" = "vmlinux" ] ; then
   img_dest=vmlinux
 else
   img_dest=vmlinuz


### PR DESCRIPTION
Running ShellCheck 0.8.0 on the `installkernel` script gave three warnings with the following text:

```
SC2086 (info): Double quote to prevent globbing and word splitting.
```